### PR TITLE
fix Slack link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We welcome contributions to the Power Functional Simulator Setup Project in many
 The project's [maintainers](MAINTAINERS.txt): are responsible for reviewing and merging all pull requests and they guide the over-all technical direction of the project.
 
 ## Communication <a name="communication"></a>
-We use [Slack](https://toolsforpower.slack.org/) for communication.
+We use [Slack](https://toolsforpower.slack.com/) for communication.
 
 ## Supported Architecture and Operating Systems
 


### PR DESCRIPTION
s/slack.org/slack.com/

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>